### PR TITLE
Add http/https proxy function

### DIFF
--- a/README.md
+++ b/README.md
@@ -69,3 +69,11 @@ es.onerror = function (err) {
   }
 };
 ```
+
+### HTTP/HTTPS proxy
+
+You can define a `proxy` option for the HTTP request to be used. This is typically useful if you are behind a corporate firewall.
+
+```javascript
+var es = new EventSource(url, { proxy: 'http://your.proxy.com' });
+```

--- a/lib/eventsource.js
+++ b/lib/eventsource.js
@@ -85,6 +85,17 @@ function EventSource(url, eventSourceInitDict) {
 
     options.rejectUnauthorized = !(eventSourceInitDict && eventSourceInitDict.rejectUnauthorized == false);
 
+    // If specify http proxy, make the request to sent to the proxy server,
+    // and include the original url in path and Host headers
+    if (eventSourceInitDict && eventSourceInitDict.proxy) {
+        var proxy = parse(eventSourceInitDict.proxy);
+        options.path = url;
+        options.headers.Host = options.host;
+        options.hostname = proxy.hostname;
+        options.host = proxy.host;
+        options.port = proxy.port;
+    }
+
     req = (isSecure ? https : http).request(options, function (res) {
       // Handle HTTP redirects
       if (res.statusCode == 301 || res.statusCode == 307) {


### PR DESCRIPTION
This PR adds the `proxy` option in the constructor so the HTTP request can go through a proxy if needed.