### PR TITLE
fix close function to abort XHR

### DIFF
--- a/lib/eventsource.js
+++ b/lib/eventsource.js
@@ -186,6 +186,7 @@ function EventSource(url, eventSourceInitDict) {
     if (readyState == EventSource.CLOSED) return;
     readyState = EventSource.CLOSED;
     if (req.abort) req.abort();
+    if (req.xhr && req.xhr.abort) req.xhr.abort();
   };
 
   function parseEventStreamLine(buf, pos, fieldLength, lineLength) {


### PR DESCRIPTION
I noticed while using the polyfill, calling the close() function was not actually closing the http connection, but making this small change to call the abort() function of the actual xhr reference fixed the problem.